### PR TITLE
chore: ignore keys.json/yaml files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# key (password) files
+keys.json
+keys.yaml
+keys.yml
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
This will prevent git from uploading our password (and other) key files into github.